### PR TITLE
Change requirements.txt to allow more flexibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-beautifulsoup4==4.11.1
-Pillow==9.3.0
-requests==2.28.1
+wheel
+beautifulsoup4 >= 4.11.1
+Pillow >= 8.4.0
+requests >= 2.27.1


### PR DESCRIPTION
Instead of requiring exact versions for modules that are needed by bird-slideshow, use >= to allow for versions known to work, or later.

Also, change the PIL version required to a lower value (8.4.0). I know that PIL 5.1.0 (the default PIL version installed on Ubuntu 18.04) doesn't work.  But the 8.4.0 version of Pillow does.

Signed-off-by: Tim Bird <tim.bird@sony.com>